### PR TITLE
Refactor: Make NewNoteUseCase callable as a function

### DIFF
--- a/app/src/main/java/com/kawunus/habityou/domain/api/usecase/NewNoteUseCase.kt
+++ b/app/src/main/java/com/kawunus/habityou/domain/api/usecase/NewNoteUseCase.kt
@@ -4,5 +4,5 @@ import com.kawunus.habityou.domain.model.Note
 
 interface NewNoteUseCase {
 
-    suspend fun execute(note: Note)
+    suspend operator fun invoke(note: Note)
 }

--- a/app/src/main/java/com/kawunus/habityou/domain/usecase/NewNoteUseCaseImpl.kt
+++ b/app/src/main/java/com/kawunus/habityou/domain/usecase/NewNoteUseCaseImpl.kt
@@ -7,7 +7,7 @@ import com.kawunus.habityou.utils.mappers.toNoteDto
 
 class NewNoteUseCaseImpl(private val repository: NoteRepository) : NewNoteUseCase {
 
-    override suspend fun execute(note: Note) {
+    override suspend operator fun invoke(note: Note) {
         repository.insertNote(note.toNoteDto())
     }
 }

--- a/app/src/main/java/com/kawunus/habityou/ui/screens/newnote/viewmodel/NewNoteViewModel.kt
+++ b/app/src/main/java/com/kawunus/habityou/ui/screens/newnote/viewmodel/NewNoteViewModel.kt
@@ -8,14 +8,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
-class NewNoteViewModel(private val newNoteUseCase: NewNoteUseCase) : ViewModel() {
+class NewNoteViewModel(private val newNote: NewNoteUseCase) : ViewModel() {
 
     private val _state = MutableStateFlow<NewNoteScreenState>(NewNoteScreenState.ReadyToCreate)
     val state = _state.asStateFlow()
 
     fun createNote(title: String, content: String) {
         viewModelScope.launch {
-            newNoteUseCase.execute(
+            newNote(
                 Note(
                     title = title,
                     content = content,


### PR DESCRIPTION
This commit refactors the `NewNoteUseCase` and its implementation `NewNoteUseCaseImpl` by adding the `operator` keyword to the `invoke` function (previously `execute`).

This allows the use case to be called directly as a function, simplifying its usage in `NewNoteViewModel`.