### PR TITLE
Feat: Add detekt and CI-CD workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @kawunus

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -1,0 +1,77 @@
+name: Build (Main)
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  main_build:
+    name: Build debug APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run Unit Tests
+        run: ./gradlew testDebugUnitTest
+
+      - name: Upload Test Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: app/build/reports/tests/
+
+      - name: Run Detekt formatting
+        run: ./gradlew detektFormat
+
+      - name: Run DetektAll
+        run: ./gradlew detektAll
+
+      - name: Run Android Lint
+        run: ./gradlew lintDebug
+
+      - name: Upload Lint Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-report
+          path: app/build/reports/lint-results-debug.html
+
+      - name: Build (Release)
+        run: ./gradlew build
+
+      - name: Assemble Release APK
+        run: ./gradlew assembleRelease
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release.apk
+          path: app/build/outputs/apk/release/app-release.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,14 +8,14 @@ plugins {
 
 android {
     namespace = "com.kawunus.habityou"
-    compileSdk = 35
+    compileSdk = libs.versions.compileSdk.get().toInt()
 
     defaultConfig {
         applicationId = "com.kawunus.habityou"
-        minSdk = 26
-        targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        minSdk = libs.versions.minSdk.get().toInt()
+        targetSdk = libs.versions.targetSdk.get().toInt()
+        versionCode = libs.versions.versionCode.get().toInt()
+        versionName = libs.versions.versionName.get()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -30,11 +30,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.valueOf(libs.versions.java.get())
+        targetCompatibility = JavaVersion.valueOf(libs.versions.java.get())
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = JavaVersion.valueOf(libs.versions.java.get()).toString()
     }
     buildFeatures {
         compose = true
@@ -62,7 +62,6 @@ dependencies {
     implementation(libs.material3)
     implementation(libs.androidx.material.icons.extended)
     implementation(libs.accompanist.navigation.animation)
-
 
 
     // Room Database

--- a/app/src/main/java/com/kawunus/habityou/ui/theme/Color.kt
+++ b/app/src/main/java/com/kawunus/habityou/ui/theme/Color.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MagicNumber")
+
 package com.kawunus.habityou.ui.theme
 
 import androidx.compose.ui.graphics.Color

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,87 @@
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     id("com.google.devtools.ksp") version "2.0.21-1.0.26"
+    alias(libs.plugins.detekt)
+}
+
+tasks.withType<Detekt>().configureEach {
+    parallel = true
+    autoCorrect = false
+    disableDefaultRuleSets = false
+    buildUponDefaultConfig = true
+    jvmTarget = JavaVersion.valueOf(libs.versions.java.get()).toString()
+    setSource(files(projectDir))
+    include("**/*.kt")
+    include("**/*.kts")
+    exclude("**/resources/**")
+    exclude("**/build/**")
+    reports {
+        xml.required.set(false)
+        html.required.set(true)
+        txt.required.set(true)
+        sarif.required.set(false)
+        md.required.set(false)
+    }
+    config.setFrom(files(project.rootDir.resolve("conf/custom-detekt.yml")))
+}
+
+tasks.register<Detekt>("detektAll") {
+    description = "Runs detekt over the whole code base"
+    group = "verification"
+    parallel = true
+    autoCorrect = false
+    disableDefaultRuleSets = false
+    buildUponDefaultConfig = false
+    jvmTarget = JavaVersion.valueOf(libs.versions.java.get()).toString()
+    setSource(files(projectDir))
+    include("**/*.kt", "**/*.kts")
+    exclude("**/resources/**", "**/build/**")
+    config.setFrom(files(rootProject.file("conf/custom-detekt.yml")))
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+        txt.required.set(true)
+    }
+}
+tasks.register<Detekt>("detektFormat") {
+    description = "Auto-corrects the code base using Detekt formatting rules"
+    group = "formatting"
+    parallel = true
+    autoCorrect = true
+    disableDefaultRuleSets = false
+    buildUponDefaultConfig = false
+    jvmTarget = JavaVersion.valueOf(libs.versions.java.get()).toString()
+    setSource(files(projectDir))
+    include("**/*.kt", "**/*.kts")
+    exclude("**/resources/**", "**/build/**")
+    config.setFrom(files(rootProject.file("conf/custom-detekt.yml")))
+    reports {
+        xml.required.set(false)
+        html.required.set(false)
+        txt.required.set(true)
+    }
+}
+tasks.register<DetektCreateBaselineTask>("detektProjectBaseline") {
+    description = "Creates or overrides the Detekt baseline"
+    group = "verification"
+    setSource(files(projectDir))
+    include("**/*.kt", "**/*.kts")
+    exclude("**/resources/**", "**/build/**")
+    buildUponDefaultConfig.set(true)
+    ignoreFailures.set(true)
+    parallel.set(true)
+    jvmTarget = JavaVersion.valueOf(libs.versions.java.get()).toString()
+    config.setFrom(files(rootProject.file("conf/custom-detekt.yml")))
+}
+
+dependencies {
+    add("detekt", libs.staticAnalysis.detektCli)
+    add("detektPlugins", libs.staticAnalysis.detektFormatting)
+    add("detektPlugins", libs.staticAnalysis.detektLibraries)
 }

--- a/conf/custom-detekt.yml
+++ b/conf/custom-detekt.yml
@@ -1,0 +1,791 @@
+build:
+  maxIssues: 0
+  excludeCorrectable: false
+  weights:
+  # complexity: 2
+  # LongParameterList: 1
+  # style: 1
+  # comments: 1
+
+config:
+  validation: true
+  warningsAsErrors: false
+  # when writing own rules with new properties, exclude the property path e.g.: 'my_rule_set,.*>.*>[my_property]'
+  excludes: ''
+
+processors:
+  active: true
+  exclude:
+    - 'DetektProgressListener'
+  # - 'KtFileCountProcessor'
+  # - 'PackageCountProcessor'
+  # - 'ClassCountProcessor'
+  # - 'FunctionCountProcessor'
+  # - 'PropertyCountProcessor'
+  # - 'ProjectComplexityProcessor'
+  # - 'ProjectCognitiveComplexityProcessor'
+  # - 'ProjectLLOCProcessor'
+  # - 'ProjectCLOCProcessor'
+  # - 'ProjectLOCProcessor'
+  # - 'ProjectSLOCProcessor'
+  # - 'LicenseHeaderLoaderExtension'
+
+console-reports:
+  active: true
+  exclude: [ ]
+
+output-reports:
+  active: true
+  exclude: [ ]
+
+# Правила для регулирования документации и лицензирования.
+comments:
+  active: false
+  excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  AbsentOrWrongFileLicense:
+    active: false
+    licenseTemplateFile: 'license.template'
+    licenseTemplateIsRegex: false
+  CommentOverPrivateFunction:
+    active: false
+  CommentOverPrivateProperty:
+    active: false
+  EndOfSentenceFormat:
+    active: false
+    endOfSentenceFormat: '([.?!][ \t\n\r\f<])|([.?!:]$)'
+  UndocumentedPublicClass:
+    active: false
+    searchInNestedClass: false
+    searchInInnerClass: false
+    searchInInnerObject: false
+    searchInInnerInterface: false
+  UndocumentedPublicFunction:
+    active: false
+  UndocumentedPublicProperty:
+    active: false
+
+# Правила для регулирования сложности кода.
+complexity:
+  active: true
+  ComplexCondition:
+    active: true
+    threshold: 4
+  # Правило выключено, потому что дублируется правилом complexity:TooManyFunctions.
+  ComplexInterface:
+    active: false
+    threshold: 10
+    includeStaticDeclarations: false
+    includePrivateDeclarations: false
+  CognitiveComplexMethod:
+    active: true
+    threshold: 15
+  CyclomaticComplexMethod:
+    active: true
+    threshold: 10
+    ignoreSingleWhenExpression: true
+    ignoreSimpleWhenEntries: true
+    ignoreNestingFunctions: false
+    nestingFunctions: [ run, let, apply, with, also, use, forEach, isNotNull, ifNull ]
+  LabeledExpression:
+    active: true
+    ignoredLabels: [ ]
+  LargeClass:
+    active: true
+    threshold: 200
+  LongMethod:
+    active: true
+    threshold: 40
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+    ignoreAnnotated: [ "Composable" ]
+  LongParameterList:
+    active: true
+    functionThreshold: 6
+    constructorThreshold: 7
+    ignoreDefaultParameters: true
+    ignoreDataClasses: true
+    ignoreAnnotated: [ "Inject", "InjectConstructor", "Composable" ]
+  MethodOverloading:
+    active: true
+    threshold: 6
+  NamedArguments:
+    active: true
+    threshold: 3
+  NestedBlockDepth:
+    active: true
+    threshold: 4
+  ReplaceSafeCallChainWithRun:
+    active: false
+  StringLiteralDuplication:
+    active: true
+    threshold: 3
+    ignoreAnnotation: true
+    excludeStringsWithLessThan5Characters: true
+    ignoreStringsRegex: '$^'
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**', '**/*.kts' ]
+  TooManyFunctions:
+    active: true
+    thresholdInFiles: 51
+    thresholdInClasses: 51
+    thresholdInInterfaces: 11
+    thresholdInObjects: 51
+    thresholdInEnums: 6
+    ignoreDeprecated: true
+    ignorePrivate: true
+    ignoreOverridden: false
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+
+# Правила для регулирования работы с корутинами.
+coroutines:
+  active: true
+  GlobalCoroutineUsage:
+    active: true
+  RedundantSuspendModifier:
+    active: true
+  SleepInsteadOfDelay:
+    active: true
+  SuspendFunWithFlowReturnType:
+    active: true
+
+# Правила для регулирования пустых блоков кода.
+empty-blocks:
+  active: true
+  EmptyCatchBlock:
+    active: true
+    allowedExceptionNameRegex: '_|(ignore|expected|ignored).*'
+  EmptyClassBlock:
+    active: true
+  EmptyDefaultConstructor:
+    active: true
+  EmptyDoWhileBlock:
+    active: true
+  EmptyElseBlock:
+    active: true
+  EmptyFinallyBlock:
+    active: true
+  EmptyForBlock:
+    active: true
+  EmptyFunctionBlock:
+    active: true
+    ignoreOverridden: false
+  EmptyIfBlock:
+    active: true
+  EmptyInitBlock:
+    active: true
+  EmptyKtFile:
+    active: true
+  EmptySecondaryConstructor:
+    active: true
+  EmptyTryBlock:
+    active: true
+  EmptyWhenBlock:
+    active: true
+  EmptyWhileBlock:
+    active: true
+
+# Правила для регулирования работы с исключениями.
+exceptions:
+  active: true
+  ExceptionRaisedInUnexpectedLocation:
+    active: true
+    methodNames: [ toString, hashCode, equals, finalize ]
+  InstanceOfCheckForException:
+    active: true
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  # Выключено, потому что иногда бывает необходимость оставить тудушки в качестве реализации
+  NotImplementedDeclaration:
+    active: false
+  ObjectExtendsThrowable:
+    active: true
+  PrintStackTrace:
+    active: true
+  # Выключено, потому что мы иногда бросаем исключения из catch-блоков, чтобы их отловить позже
+  RethrowCaughtException:
+    active: false
+  ReturnFromFinally:
+    active: true
+    ignoreLabeled: false
+  SwallowedException:
+    active: true
+    ignoredExceptionTypes:
+      - InterruptedException
+      - NumberFormatException
+      - ParseException
+      - MalformedURLException
+    allowedExceptionNameRegex: '_|(ignore|expected|ignored).*'
+  ThrowingExceptionFromFinally:
+    active: true
+  ThrowingExceptionInMain:
+    active: false
+  ThrowingExceptionsWithoutMessageOrCause:
+    active: true
+    exceptions:
+      - IllegalArgumentException
+      - IllegalStateException
+      - IOException
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  ThrowingNewInstanceOfSameException:
+    active: true
+  TooGenericExceptionCaught:
+    active: true
+    exceptionNames:
+      - ArrayIndexOutOfBoundsException
+      - Error
+      - Exception
+      - IllegalMonitorStateException
+      - NullPointerException
+      - IndexOutOfBoundsException
+      - RuntimeException
+      - Throwable
+    allowedExceptionNameRegex: '_|(ignore|expected|ignored).*'
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  TooGenericExceptionThrown:
+    active: true
+    exceptionNames:
+      - Error
+      - Exception
+      - Throwable
+      - RuntimeException
+
+# Правила форматирования кодовой базы.
+formatting:
+  active: true
+  android: false
+  autoCorrect: true
+  AnnotationOnSeparateLine:
+    active: true
+    autoCorrect: true
+  AnnotationSpacing:
+    active: true
+    autoCorrect: true
+  ArgumentListWrapping:
+    active: true
+    autoCorrect: true
+    indentSize: 4
+    maxLineLength: 120
+  ChainWrapping:
+    active: false
+    autoCorrect: false
+  CommentSpacing:
+    active: true
+    autoCorrect: true
+  EnumEntryNameCase:
+    active: true
+    autoCorrect: true
+  Filename:
+    active: true
+  FinalNewline:
+    active: false
+    autoCorrect: true
+    insertFinalNewLine: true
+  ImportOrdering:
+    active: true
+    autoCorrect: true
+    layout: '*,java.**,javax.**,kotlin.**,kotlinx.android.synthetic.**,^'
+  Indentation:
+    active: true
+    autoCorrect: true
+    indentSize: 4
+    #continuationIndentSize: 4
+  # Правило выключено, потому что дублируется правилом style:MaxLineLength
+  MaximumLineLength:
+    active: false
+    maxLineLength: 120
+    ignoreBackTickedIdentifier: false
+  ModifierOrdering:
+    active: true
+    autoCorrect: true
+  MultiLineIfElse:
+    active: true
+    autoCorrect: true
+  # Правило выключено, потому что удобно оставлять пустую строчку
+  # перед закрывающей скобкой класса
+  NoBlankLineBeforeRbrace:
+    active: false
+    autoCorrect: false
+  # Правило выключено, потому что иногда мы ставим больше одной пустой строки
+  # между, например, property и функциями
+  NoConsecutiveBlankLines:
+    active: false
+    autoCorrect: true
+  NoEmptyClassBody:
+    active: true
+    autoCorrect: true
+  NoEmptyFirstLineInMethodBlock:
+    active: true
+    autoCorrect: true
+  NoLineBreakAfterElse:
+    active: true
+    autoCorrect: true
+  NoLineBreakBeforeAssignment:
+    active: true
+    autoCorrect: true
+  NoMultipleSpaces:
+    active: true
+    autoCorrect: true
+  NoSemicolons:
+    active: true
+    autoCorrect: true
+  NoTrailingSpaces:
+    active: true
+    autoCorrect: true
+  NoUnitReturn:
+    active: true
+    autoCorrect: true
+  NoUnusedImports:
+    active: true
+    autoCorrect: true
+  # Правило выключено, потому что оно дублируется правилом WildcardImport, которое лучше настраивается.
+  NoWildcardImports:
+    active: false
+  # Правило выключено, потому что мы разрешаем использовать '_' в имени пакета
+  # Правило дублируется правилом naming:PackageNaming
+  PackageName:
+    active: false
+    autoCorrect: false
+  ParameterListWrapping:
+    active: true
+    autoCorrect: true
+    indentSize: 4
+    maxLineLength: 120
+  SpacingAroundAngleBrackets:
+    active: true
+    autoCorrect: true
+  SpacingAroundColon:
+    active: true
+    autoCorrect: true
+  SpacingAroundComma:
+    active: true
+    autoCorrect: true
+  SpacingAroundCurly:
+    active: true
+    autoCorrect: true
+  SpacingAroundDot:
+    active: true
+    autoCorrect: true
+  SpacingAroundDoubleColon:
+    active: true
+    autoCorrect: true
+  SpacingAroundKeyword:
+    active: true
+    autoCorrect: true
+  SpacingAroundOperators:
+    active: true
+    autoCorrect: true
+  SpacingAroundParens:
+    active: true
+    autoCorrect: true
+  SpacingAroundRangeOperator:
+    active: true
+    autoCorrect: true
+  SpacingAroundUnaryOperator:
+    active: true
+    autoCorrect: true
+  # Правило выключено, потому что оно дублируется
+  # правилом AnnotationOnSeparateLine
+  SpacingBetweenDeclarationsWithAnnotations:
+    active: false
+    autoCorrect: false
+  SpacingBetweenDeclarationsWithComments:
+    active: true
+    autoCorrect: true
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  StringTemplate:
+    active: true
+    autoCorrect: true
+
+# Правила именования переменных / функций / классов и т.п.
+naming:
+  active: true
+  ClassNaming:
+    active: true
+    classPattern: '([A-Z$][a-zA-Z0-9$]*|[_A-Z]*(_SCREEN)*)'
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  ConstructorParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    privateParameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  EnumNaming:
+    active: true
+    enumEntryPattern: '^[A-Z][_a-zA-Z0-9]*'
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  # Правило выключено, потому что мы не ограничиваем фантазию разработчиков
+  # в вопросе именования классов
+  ForbiddenClassName:
+    active: false
+    forbiddenName: [ ]
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  # Правило выключено, потому что иногда возникает необходимость в длинном имени
+  FunctionMaxLength:
+    active: false
+    maximumFunctionNameLength: 30
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  # Правило выключено, потому что бывают функции, которые в определённом
+  # контексте имеют право называться коротким именем (в 1 символ)
+  FunctionMinLength:
+    active: false
+    minimumFunctionNameLength: 3
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  FunctionNaming:
+    active: true
+    functionPattern: '([a-z][a-zA-Z0-9]*)|(`.*`)'
+    excludeClassPattern: '$^'
+    ignoreAnnotated: [ 'Composable' ]
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  FunctionParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  InvalidPackageDeclaration:
+    active: true
+    excludes: [ '**/*.kts' ]
+    rootPackage: ''
+  MatchingDeclarationName:
+    active: true
+    mustBeFirst: true
+  MemberNameEqualsClassName:
+    active: true
+    ignoreOverridden: true
+  NoNameShadowing:
+    active: true
+  NonBooleanPropertyPrefixedWithIs:
+    active: true
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  ObjectPropertyNaming:
+    active: true
+    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  PackageNaming:
+    active: true
+    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**', '**/uikit_sample/**' ]
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+
+    # Правило выключено, потому что иногда возникает необходимость в длинном
+    # имени переменной
+  VariableMaxLength:
+    active: false
+    maximumVariableNameLength: 64
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+
+    # Правило выключено, потому что иногда возникает необходимость в коротком
+    # имени переменной
+  VariableMinLength:
+    active: false
+    minimumVariableNameLength: 1
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  VariableNaming:
+    active: true
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+
+# Набор правил для анализа кода на проблемы с производительностью.
+performance:
+  active: true
+  ArrayPrimitive:
+    active: true
+  ForEachOnRange:
+    active: true
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  SpreadOperator:
+    active: false
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  UnnecessaryTemporaryInstantiation:
+    active: true
+
+# Набор правил для анализа кода на потенциальные баги.
+potential-bugs:
+  active: true
+  CastToNullableType:
+    active: true
+  Deprecation:
+    active: true
+  DontDowncastCollectionTypes:
+    active: true
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: true
+  EqualsWithHashCodeExist:
+    active: true
+  ExitOutsideMain:
+    active: true
+  ExplicitGarbageCollectionCall:
+    active: true
+  HasPlatformType:
+    active: true
+  IgnoredReturnValue:
+    active: true
+    restrictToConfig: true
+    returnValueAnnotations: [ '*.CheckReturnValue', '*.CheckResult' ]
+  ImplicitDefaultLocale:
+    active: true
+  ImplicitUnitReturnType:
+    active: true
+    allowExplicitReturnType: false
+  InvalidRange:
+    active: true
+  IteratorHasNextCallsNextMethod:
+    active: true
+  IteratorNotThrowingNoSuchElementException:
+    active: true
+  LateinitUsage:
+    active: true
+    ignoreAnnotated: [ 'Inject' ]
+    ignoreOnClassesPattern: ''
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  MapGetWithNotNullAssertionOperator:
+    active: true
+  NullableToStringCall:
+    active: true
+  UnconditionalJumpStatementInLoop:
+    active: true
+  UnnecessaryNotNullOperator:
+    active: true
+  UnnecessarySafeCall:
+    active: true
+  UnreachableCatchBlock:
+    active: true
+  UnreachableCode:
+    active: true
+  UnsafeCallOnNullableType:
+    active: true
+  UnsafeCast:
+    active: true
+  UnusedUnaryOperator:
+    active: true
+  UselessPostfixExpression:
+    active: true
+  WrongEqualsTypeParameter:
+    active: true
+
+# Набор правил, регулирующий применение определённого код-стайла.
+style:
+  active: true
+  # Выключено, потому что мы нигде не соблюдаем порядок модификаторов
+  # видимости, указанный в "kotlin convention"
+  ClassOrdering:
+    active: false
+  CollapsibleIfStatements:
+    active: true
+  DataClassContainsFunctions:
+    active: true
+    conversionFunctionPrefix: [ ]
+  DataClassShouldBeImmutable:
+    active: true
+  DestructuringDeclarationWithTooManyEntries:
+    active: true
+    maxDestructuringEntries: 3
+  EqualsNullCall:
+    active: true
+  EqualsOnSignatureLine:
+    active: true
+  ExplicitCollectionElementAccessMethod:
+    active: true
+  ExplicitItLambdaParameter:
+    active: true
+  # Выключено, потому что мы разрешаем писать функции из 1 выражения
+  # в виде block statement
+  ExpressionBodySyntax:
+    active: false
+    includeLineWrapping: false
+  ForbiddenComment:
+    active: true
+    comments: [ 'TODO', 'FIXME', 'STOPSHIP' ]
+    allowedPatterns: 'PORTFOLIO-[0-9]+|MOB-[0-9]+|HH-[0-9]+'
+  # Выключено, потому что не возникало необходимости запрещать import-ы
+  # конкретных сущностей
+  ForbiddenImport:
+    active: false
+    imports: [ ]
+    forbiddenPatterns: ''
+  ForbiddenMethodCall:
+    active: true
+    methods: [ {
+      value: 'kotlin.io.println'
+    }, {
+      value: 'kotlin.io.print'
+    } ]
+  ForbiddenVoid:
+    active: true
+    ignoreOverridden: false
+    ignoreUsageInGenerics: false
+  FunctionOnlyReturningConstant:
+    active: true
+    ignoreOverridableFunction: true
+    ignoreActualFunction: true
+    excludedFunctions: [ 'describeContents' ]
+    ignoreAnnotated: [ 'dagger.Provides' ]
+  LoopWithTooManyJumpStatements:
+    active: true
+    maxJumpCount: 1
+  MagicNumber:
+    active: true
+    ignoreNumbers: [ '-1', '0', '1', '2' ]
+    ignoreHashCodeFunction: true
+    ignorePropertyDeclaration: false
+    ignoreLocalVariableDeclaration: false
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotation: false
+    ignoreNamedArgument: true
+    ignoreEnums: false
+    ignoreRanges: false
+    ignoreExtensionFunctions: true
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  BracesOnIfStatements:
+    active: true
+    singleLine: 'never'
+    multiLine: 'always'
+  MandatoryBracesLoops:
+    active: true
+  MaxLineLength:
+    active: true
+    maxLineLength: 120
+    excludePackageStatements: true
+    excludeImportStatements: true
+    excludeCommentStatements: true
+  MayBeConst:
+    active: true
+  ModifierOrder:
+    active: true
+  MultilineLambdaItParameter:
+    active: true
+  NestedClassesVisibility:
+    active: true
+  # Выключено, потому что дублируется правилом formatting:FinalNewLine
+  # + в другом правиле есть автоисправление
+  NewLineAtEndOfFile:
+    active: false
+  NoTabs:
+    active: true
+  OptionalAbstractKeyword:
+    active: true
+  OptionalUnit:
+    active: false
+  # Выключено, потому что по нашему код-стайлу даже в единичных выражениях
+  # внутри when мы иногда ставим фигурные скобки
+  BracesOnWhenStatements:
+    active: false
+  # Выключено, потому что мы обычно используем явные конструкторы Pair-а, где
+  # нужно, а где можно - используем оператор to.
+  PreferToOverPairSyntax:
+    active: false
+  ProtectedMemberInFinalClass:
+    active: true
+  RedundantExplicitType:
+    active: true
+  RedundantHigherOrderMapUsage:
+    active: true
+  RedundantVisibilityModifierRule:
+    active: true
+  ReturnCount:
+    active: true
+    max: 2
+    excludedFunctions: [ 'equals' ]
+    excludeLabeled: false
+    excludeReturnFromLambda: true
+    excludeGuardClauses: false
+  SafeCast:
+    active: true
+  SerialVersionUIDInSerializableClass:
+    active: true
+  SpacingBetweenPackageAndImports:
+    active: true
+  ThrowsCount:
+    active: true
+    max: 2
+  # Правило выключено, потому что дублируется правилом formatting:NoTrailingSpaces, у которого есть автофикс
+  TrailingWhitespace:
+    active: false
+  UnderscoresInNumericLiterals:
+    active: true
+    acceptableLength: 5
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+  UnnecessaryAbstractClass:
+    active: true
+    ignoreAnnotated: [ 'dagger.Module' ]
+  UnnecessaryAnnotationUseSiteTarget:
+    active: true
+  UnnecessaryApply:
+    active: true
+  UnnecessaryFilter:
+    active: true
+  UnnecessaryInheritance:
+    active: true
+  UnnecessaryLet:
+    active: true
+  UnnecessaryParentheses:
+    active: true
+  UntilInsteadOfRangeTo:
+    active: true
+  # Правило выключено, потому что дублируется правилом formatting:NoUnusedImports
+  UnusedImports:
+    active: false
+  UnusedPrivateClass:
+    active: true
+  UnusedPrivateMember:
+    active: true
+    allowedNames: '(_|ignored|expected|serialVersionUID|commonMain|commonTest|androidMain|androidTest|iosMain|iosTest)'
+    ignoreAnnotated: [ 'Preview', 'LightDarkPreviews' ]
+  UseArrayLiteralsInAnnotations:
+    active: true
+  UseCheckNotNull:
+    active: true
+  UseCheckOrError:
+    active: true
+  # Выключено, потому что data-классы не всегда нужно использовать, если
+  # класс хранит в себе только данные.
+  UseDataClass:
+    active: false
+    ignoreAnnotated: [ ]
+    allowVars: false
+  UseEmptyCounterpart:
+    active: true
+  UseIfEmptyOrIfBlank:
+    active: true
+  # Выключено, потому что иногда выражение when с 2 ветками понятнее, чем if
+  UseIfInsteadOfWhen:
+    active: false
+  UseIsNullOrEmpty:
+    active: true
+  UseOrEmpty:
+    active: true
+  UseRequire:
+    active: true
+  UseRequireNotNull:
+    active: true
+  UselessCallOnNotNull:
+    active: true
+  UtilityClassWithPublicConstructor:
+    active: true
+  VarCouldBeVal:
+    active: true
+  WildcardImport:
+    active: true
+    excludeImports: [ 'java.util.*', 'kotlinx.android.synthetic.*' ]
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+
+libraries:
+  # Выключено, потому что наши core-модули могут выставлять наружу data class-ы
+  ForbiddenPublicDataClass:
+    active: false
+    excludes: [ '**' ]
+    ignorePackages: [ '*.internal', '*.internal.*' ]
+  LibraryCodeMustSpecifyReturnType:
+    active: true
+    excludes: [ '**' ]
+  # Выключено, потому что наши core-модули могут выставлять наружу свои классы,
+  # не закрытые интерфейсами
+  LibraryEntitiesShouldNotBePublic:
+    active: false
+    excludes: [ '**' ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,17 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# dont delete APK after instrumental test
+android.injected.androidTest.leaveApksInstalledAfterRun=true
+# includes parallel building of modules
+org.gradle.configureondemand=true
+org.gradle.parallel=true
+#configuration cache
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.unsafe.configuration-cache=true
+kotlin.incremental=true
+org.gradle.unsafe.configuration-cache-problems=warn
+org.gradle.unsafe.configuration-cache.max-problems=2
+android.enableBuildConfigAsBytecode=true
+android.defaults.buildfeatures.buildconfig=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,12 @@
 [versions]
+versionCode = "1"
+versionName = "1.0"
+
+minSdk = "26"
+targetSdk = "35"
+compileSdk = "35"
+java = "VERSION_17"
+
 accompanistNavigationAnimation = "0.34.0"
 agp = "8.10.0"
 koinAndroid = "4.0.4"
@@ -17,6 +25,7 @@ material3 = "1.3.2"
 materialIconsExtended = "1.7.8"
 navigationCompose = "2.9.0"
 roomKtx = "2.7.1"
+detekt = "1.23.8"
 
 [libraries]
 accompanist-navigation-animation = { module = "com.google.accompanist:accompanist-navigation-animation", version.ref = "accompanistNavigationAnimation" }
@@ -44,9 +53,15 @@ koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", versi
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koinCore" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
 material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
+# Detekt
+staticAnalysis-detektCli = { module = "io.gitlab.arturbosch.detekt:detekt-cli", version.ref = "detekt" }
+staticAnalysis-detektFormatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+staticAnalysis-detektLibraries = { module = "io.gitlab.arturbosch.detekt:detekt-rules-libraries", version.ref = "detekt" }
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 


### PR DESCRIPTION
This commit introduces Detekt for static code analysis and a GitHub Actions workflow for continuous integration and delivery.

Key changes:
- Integrated Detekt with custom configuration (`conf/custom-detekt.yml`).
- Added Detekt tasks to `build.gradle.kts` for formatting, analysis, and baseline generation.
- Created a GitHub Actions workflow (`.github/workflows/build-main.yml`) that:
    - Builds the debug APK on pushes to the `main` branch and on manual dispatch.
    - Caches Gradle packages.
    - Sets up JDK and Android SDK.
    - Runs unit tests and uploads reports.
    - Runs Detekt formatting and analysis.
    - Runs Android Lint and uploads reports.
    - Builds and assembles the release APK.
    - Uploads the release APK as an artifact.
- Centralized project versions (SDKs, Java, app version) in `gradle/libs.versions.toml`.
- Updated `app/build.gradle.kts` to use version catalog for SDK and Java versions.
- Added `.github/CODEOWNERS` file.
- Enabled various Gradle build optimizations in `gradle.properties`.
- Suppressed `MagicNumber` lint warning in `Color.kt`.